### PR TITLE
fix: propagate input data asset and add usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,17 @@
 ![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen?logo=codecov)
 ![Python](https://img.shields.io/badge/python->=3.7-blue?logo=python)
 
-Library to contain useful utility methods to interface with the code ocean index.
+Library to contain useful utility methods to interface with Code Ocean.
 
 ## Installation
-To use the software, in the root directory, run
+
+To use the package, you can install it from `pypi`:
+```bash
+pip install aind-codeocean-utils
+```
+
+
+To install the package from source, in the root directory, run
 ```bash
 pip install -e .
 ```
@@ -19,6 +26,84 @@ To develop the code, run
 ```bash
 pip install -e .[dev]
 ```
+
+## Usage
+
+The package includes helper functions to interact with Code Ocean:
+
+### `CodeOceanJob`
+
+This class enables one to run a job that:
+
+1. Registers a new asset to Code Ocean from s3
+2. Runs a capsule/pipeline on the newly registered asset (or an existing assey)
+3. Captures the run results into a new asset
+
+Steps 1 and 3 are optional, while step 2 (running the computation) is mandatory.
+
+Here is a full example that registers a new ecephys asset, runs the spike sorting
+capsule with some parameters, and registers the results:
+
+```python
+import os
+
+from aind_codeocean_api.codeocean import CodeOceanClient
+from aind_codeocean_utils.codeocean_job import (
+    CodeOceanJob, CodeOceanJobConfig
+)
+
+# Set up the CodeOceanClient from aind_codeocean_api
+CO_TOKEN = os.environ["CO_TOKEN"]
+CO_DOMAIN = os.environ["CO_DOMAIN"]
+
+co_client = CodeOceanClient(domain=CO_DOMAIN, token=CO_TOKEN)
+
+# Define Job Parameters
+job_config_dict = dict(
+    register_config = dict(
+        asset_name="test_dataset_for_codeocean_job",
+        mount="ecephys_701305_2023-12-26_12-22-25",
+        bucket="aind-ephys-data",
+        prefix="ecephys_701305_2023-12-26_12-22-25",
+        tags=["codeocean_job_test", "ecephys", "701305", "raw"],
+        custom_metadata={
+            "modality": "extracellular electrophysiology",
+            "data level": "raw data",
+        },
+        viewable_to_everyone=True
+    ),
+    run_capsule_config = dict(
+        data_assets=None, # when None, the newly registered asset will be used
+        capsule_id="a31e6c81-49a5-4f1c-b89c-2d47ae3e02b4",
+        run_parameters=["--debug", "--no-remove-out-channels"]
+    ),
+    capture_result_config = dict(
+        process_name="sorted",
+        tags=["np-ultra"] # additional tags to the ones inherited from input
+    )
+)
+
+# instantiate config model
+job_config = CodeOceanJobConfig(**job_config_dict)
+
+# instantiate code ocean job
+co_job = CodeOceanJob(co_client=co_client, job_config=job_config)
+
+# run and wait for results
+job_response = co_job.run_job()
+```
+
+This job will:
+1. Register the `test_dataset_for_codeocean_job` asset from the specified s3 bucket and prefix
+2. Run the capsule `a31e6c81-49a5-4f1c-b89c-2d47ae3e02b4` with the specified parameters
+3. Register the result as `test_dataset_for_codeocean_job_sorter_{date-time}`
+
+
+To run a computation on existing data assets, do not provide the `register_config` and
+provide the `data_asset` field in the `run_capsule_config`.
+
+To skip capturing the result, do not provide the `capture_result_config` option.
+
 
 ## Contributing
 

--- a/src/aind_codeocean_utils/codeocean_job.py
+++ b/src/aind_codeocean_utils/codeocean_job.py
@@ -165,7 +165,9 @@ class CodeOceanJob:
                 break_flag = True
         return response
 
-    def check_data_assets(self, data_assets: List[ComputationDataAsset]) -> bool:
+    def check_data_assets(
+        self, data_assets: List[ComputationDataAsset]
+    ) -> None:
         """
         Check if data assets exist.
 
@@ -174,15 +176,17 @@ class CodeOceanJob:
         data_assets : list
             List of data assets to check for.
 
-        Returns
-        -------
-        bool
-            Whether the data assets exist or not.
+        Raises
+        ------
+        FileNotFoundError
+            If a data asset is not found.
+        ConnectionError
+            If there is an issue retrieving a data asset.
         """
         for data_asset in data_assets:
-            assert isinstance(data_asset, ComputationDataAsset), (
-                "Data assets must be of type ComputationDataAsset"
-            )
+            assert isinstance(
+                data_asset, ComputationDataAsset
+            ), "Data assets must be of type ComputationDataAsset"
             data_asset_id = data_asset.id
             response = self.co_client.get_data_asset(data_asset_id)
             if response.status_code == 404:
@@ -191,12 +195,11 @@ class CodeOceanJob:
                 raise ConnectionError(
                     f"There was an issue retrieving: {data_asset_id}"
                 )
-        return True
 
     def _run_capsule(
         self,
         run_capsule_config: RunCapsuleConfig,
-        input_data_assets: List[ComputationDataAsset] = None
+        input_data_assets: List[ComputationDataAsset] = None,
     ) -> requests.Response:
         """
         Run a specified capsule with the given data assets. If the
@@ -498,8 +501,9 @@ class CodeOceanJob:
                     self.job_config.register_config
                 )
             )
-            register_data_asset_response_json = \
+            register_data_asset_response_json = (
                 register_data_asset_response.json()
+            )
             input_data_assets = [
                 ComputationDataAsset(
                     id=register_data_asset_response_json["id"],
@@ -535,7 +539,7 @@ class CodeOceanJob:
         logger.info("Running capsule")
         run_capsule_response = self._run_capsule(
             self.job_config.run_capsule_config,
-            input_data_assets=input_data_assets
+            input_data_assets=input_data_assets,
         )
         responses["run"] = run_capsule_response
 

--- a/src/aind_codeocean_utils/models/config.py
+++ b/src/aind_codeocean_utils/models/config.py
@@ -49,6 +49,14 @@ class RegisterDataConfig(BaseModel):
         else:
             return []
 
+    @field_validator("custom_metadata", mode="before")
+    def check_custom_metadata(cls, v: Optional[Dict]) -> Dict:
+        """Allows user to input None and converts them to empty collection"""
+        if v is not None:
+            return v
+        else:
+            return dict()
+
 
 class RunCapsuleConfig(BaseModel):
     """
@@ -104,10 +112,10 @@ class RunCapsuleConfig(BaseModel):
         cls, v: Optional[list]
     ) -> Optional[List[ComputationDataAsset]]:
         """
-        Coerces dictionaries into ComputationDataAsset type
+        Coerces dictionaries into ComputationDataAsset type or emtpy list
         """
         if v is None:
-            return None
+            return v
         else:
             updated_list = []
             for item in v:
@@ -137,8 +145,8 @@ class CaptureResultConfig(BaseModel):
     tags: List[str] = Field(
         default=[], description="The tags to use to describe the data asset."
     )
-    custom_metadata: Optional[Dict] = Field(
-        default=None,
+    custom_metadata: Dict = Field(
+        default=dict(),
         description="What key:value metadata tags to apply to the asset.",
     )
     viewable_to_everyone: bool = Field(
@@ -153,6 +161,14 @@ class CaptureResultConfig(BaseModel):
             return v
         else:
             return []
+
+    @field_validator("custom_metadata", mode="before")
+    def check_custom_metadata(cls, v: Optional[Dict]) -> Dict:
+        """Allows user to input None and converts them to empty collection"""
+        if v is not None:
+            return v
+        else:
+            return dict()
 
     @field_validator("asset_name", mode="after")
     def validate_asset_name(

--- a/tests/test_codeocean_job.py
+++ b/tests/test_codeocean_job.py
@@ -863,6 +863,25 @@ class TestCodeOceanJob(unittest.TestCase):
         mock_capture_result: MagicMock,
     ):
         """Tests run_job method"""
+        some_register_response = requests.Response()
+        some_register_response.status_code = 200
+        fake_register_id = "12345"
+        some_register_response.json = lambda: (
+            {
+                "created": 1666322134,
+                "description": "",
+                "files": 1364,
+                "id": fake_register_id,
+                "last_used": 0,
+                "name": "some_asset_name",
+                "state": "draft",
+                "custom_metadata": self.basic_codeocean_job_config.register_config.custom_metadata,
+                "tags": self.basic_codeocean_job_config.register_config.tags,
+                "type": "dataset",
+            }
+        )
+        mock_register_data.return_value = some_register_response
+
         some_run_response = requests.Response()
         some_run_response.status_code = 200
         fake_computation_id = "comp-abc-123"
@@ -886,9 +905,17 @@ class TestCodeOceanJob(unittest.TestCase):
         mock_register_data.assert_called_once_with(
             self.basic_codeocean_job_config.register_config
         )
+
         mock_run_capsule.assert_called_once_with(
-            self.basic_codeocean_job_config.run_capsule_config
+            self.basic_codeocean_job_config.run_capsule_config,
+            input_data_assets=[
+                ComputationDataAsset(
+                    id=fake_register_id,
+                    mount=self.basic_codeocean_job_config.register_config.mount
+                )
+            ],
         )
+
         # the run_capsule will propagate the additional_tags and
         # additional_custom_metadata to the _capture_result method
         mock_capture_result.assert_called_once_with(
@@ -934,9 +961,6 @@ class TestCodeOceanJob(unittest.TestCase):
         )
         codeocean_job.run_job()
 
-        mock_run_capsule.assert_called_once_with(
-            self.no_reg_codeocean_job_config.run_capsule_config
-        )
         mock_capture_result.assert_called_once_with(
             computation_id=fake_computation_id,
             input_data_asset_name="some_asset_name",
@@ -1019,7 +1043,8 @@ class TestCodeOceanJob(unittest.TestCase):
         codeocean_job.run_job()
         mock_register_data.assert_not_called()
         mock_run_capsule.assert_called_once_with(
-            self.one_asset_codeocean_job_config.run_capsule_config
+            self.one_asset_codeocean_job_config.run_capsule_config,
+            input_data_assets=None,
         )
         # the run_capsule will propagate the additional_tags and
         # additional_custom_metadata to the _capture_result method
@@ -1090,7 +1115,8 @@ class TestCodeOceanJob(unittest.TestCase):
         codeocean_job.run_job()
         mock_register_data.assert_not_called()
         mock_run_capsule.assert_called_once_with(
-            self.none_vals_codeocean_job_config.run_capsule_config
+            self.none_vals_codeocean_job_config.run_capsule_config,
+            input_data_assets=None
         )
         # the run_capsule will propagate the additional_tags and
         # additional_custom_metadata to the _capture_result method
@@ -1106,4 +1132,7 @@ class TestCodeOceanJob(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    # unittest.main()
+    test = TestCodeOceanJob()
+    test.setUpClass()
+    test.test_run_job()

--- a/tests/test_codeocean_job.py
+++ b/tests/test_codeocean_job.py
@@ -226,7 +226,10 @@ class TestCodeOceanJob(unittest.TestCase):
             codeocean_job._run_capsule(
                 run_capsule_config=(
                     self.basic_codeocean_job_config.run_capsule_config
-                )
+                ),
+                input_data_assets=[
+                    ComputationDataAsset(id="999888", mount="some_mount")
+                ],
             )
 
         self.assertEqual(
@@ -866,6 +869,10 @@ class TestCodeOceanJob(unittest.TestCase):
         some_register_response = requests.Response()
         some_register_response.status_code = 200
         fake_register_id = "12345"
+        custom_metadata = (
+            self.basic_codeocean_job_config.register_config.custom_metadata
+        )
+        register_mount = self.basic_codeocean_job_config.register_config.mount
         some_register_response.json = lambda: (
             {
                 "created": 1666322134,
@@ -875,7 +882,7 @@ class TestCodeOceanJob(unittest.TestCase):
                 "last_used": 0,
                 "name": "some_asset_name",
                 "state": "draft",
-                "custom_metadata": self.basic_codeocean_job_config.register_config.custom_metadata,
+                "custom_metadata": custom_metadata,
                 "tags": self.basic_codeocean_job_config.register_config.tags,
                 "type": "dataset",
             }
@@ -911,7 +918,7 @@ class TestCodeOceanJob(unittest.TestCase):
             input_data_assets=[
                 ComputationDataAsset(
                     id=fake_register_id,
-                    mount=self.basic_codeocean_job_config.register_config.mount
+                    mount=register_mount,
                 )
             ],
         )
@@ -1116,7 +1123,7 @@ class TestCodeOceanJob(unittest.TestCase):
         mock_register_data.assert_not_called()
         mock_run_capsule.assert_called_once_with(
             self.none_vals_codeocean_job_config.run_capsule_config,
-            input_data_assets=None
+            input_data_assets=None,
         )
         # the run_capsule will propagate the additional_tags and
         # additional_custom_metadata to the _capture_result method
@@ -1132,7 +1139,4 @@ class TestCodeOceanJob(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    # unittest.main()
-    test = TestCodeOceanJob()
-    test.setUpClass()
-    test.test_run_job()
+    unittest.main()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -196,6 +196,13 @@ class TestCaptureResultConfig(unittest.TestCase):
         c = CaptureResultConfig(process_name="some_process", tags=None)
         self.assertEqual([], c.tags)
 
+    def test_check_custom_metadata(self):
+        """Tests check_custom_metadata validator"""
+        c = CaptureResultConfig(
+            process_name="some_process", custom_metadata=None
+        )
+        self.assertEqual({}, c.custom_metadata)
+
     def test_asset_name_validator(self):
         """Tests asset_name validator"""
         with self.assertRaises(ValueError) as e:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -77,7 +77,7 @@ class TestRegisterDataConfig(unittest.TestCase):
         self.assertFalse(r.public)
         self.assertTrue(r.keep_on_external_storage)
         self.assertEqual([], r.tags)
-        self.assertEqual(None, r.custom_metadata)
+        self.assertEqual({}, r.custom_metadata)
         self.assertFalse(r.viewable_to_everyone)
 
 
@@ -188,7 +188,7 @@ class TestCaptureResultConfig(unittest.TestCase):
         self.assertEqual(None, c.mount)
         self.assertEqual(None, c.asset_name)
         self.assertEqual([], c.tags)
-        self.assertEqual(None, c.custom_metadata)
+        self.assertEqual({}, c.custom_metadata)
         self.assertFalse(c.viewable_to_everyone)
 
     def test_check_tags(self):


### PR DESCRIPTION
@jtyoung84 

I fixed a couple of minor issues that were not tested correctly with Mock:

1. the data asset from registration was not passed to the run capsule --> now the `_run_capsule` accepts optional `input_data_assets` (so that we don't change models on the fly).

2. there were some issues with custom_metadata and tags being None in the `capture_results` --> added a field validator and changed defaults.