### PR TITLE
Add option to specify different mount point for registered data

### DIFF
--- a/src/aind_codeocean_utils/codeocean_job.py
+++ b/src/aind_codeocean_utils/codeocean_job.py
@@ -508,10 +508,14 @@ class CodeOceanJob:
             register_data_asset_response_json = (
                 register_data_asset_response.json()
             )
+            if self.job_config.run_capsule_config.input_data_mount:
+                input_data_mount = self.job_config.run_capsule_config.input_data_mount
+            else:
+                input_data_mount = self.job_config.register_config.mount
             input_data_assets = [
                 ComputationDataAsset(
                     id=register_data_asset_response_json["id"],
-                    mount=self.job_config.register_config.mount,
+                    mount=input_data_mount,
                 )
             ]
             data_asset_tags = self.job_config.register_config.tags

--- a/src/aind_codeocean_utils/models/config.py
+++ b/src/aind_codeocean_utils/models/config.py
@@ -73,7 +73,14 @@ class RunCapsuleConfig(BaseModel):
     )
     data_assets: Optional[List[ComputationDataAsset]] = Field(
         default=None,
-        description=("List of data assets for the capsule to run against. "),
+        description="List of data assets for the capsule to run against.",
+    )
+    input_data_mount: Optional[str] = Field(
+        default=None,
+        description=(
+            "The mount point for the newly registered input data asset, "
+            "if different than the asset mount name."
+        )
     )
     run_parameters: Optional[List] = Field(
         default=None, description="The parameters to pass to the capsule."


### PR DESCRIPTION
This PR adds the option to specify a different mount point for the newly registered data asset with the `input_data_mount` field of the `RunCapsuleConfig`.

This is needed, for example, for running the ecephys pipeline, where the data asset needs to be mounted as `ecephys`