### PR TITLE
Add alert bot

### DIFF
--- a/src/aind_codeocean_utils/alert_bot.py
+++ b/src/aind_codeocean_utils/alert_bot.py
@@ -1,0 +1,76 @@
+import requests
+from typing import Optional
+
+
+
+class AlertBot:
+    """Class to handle sending alerts and messages in MS Teams."""
+
+    def __init__(self, url: str):
+        self.url = url
+
+    @staticmethod
+    def _create_body_text(message: str, extra_text: Optional[str]) -> dict:
+        """
+        Parse strings into appropriate format to send to ms teams channel.
+        Check here:
+          https://learn.microsoft.com/en-us/microsoftteams/platform/
+          task-modules-and-cards/cards/cards-reference#adaptive-card
+        Parameters
+        ----------
+        message : str
+          The main message content
+        extra_text : Optional[str]
+          Additional text to send in card body
+
+        Returns
+        -------
+        dict
+
+        """
+        body: list = [
+            {"type": "TextBlock", "size": "Medium", "weight": "Bolder", "text": message}
+        ]
+        if extra_text is not None:
+            body.append({"type": "TextBlock", "text": extra_text})
+        contents = {
+            "type": "message",
+            "attachments": [
+                {
+                    "contentType": "application/vnd.microsoft.card.adaptive",
+                    "content": {
+                        "type": "AdaptiveCard",
+                        "body": body,
+                        "$schema": (
+                            "http://adaptivecards.io/schemas/adaptive-card.json"
+                        ),
+                        "version": "1.0",
+                    },
+                }
+            ],
+        }
+        return contents
+
+    def send_message(
+        self, message: str, extra_text: Optional[str] = None
+    ) -> Optional[requests.Response]:
+        """
+        Sends a message  via requests.post
+
+        Parameters
+        ----------
+        message : str
+          The main message content
+        extra_text : Optional[str]
+          Additional text to send in card body
+
+        Returns
+        -------
+        Optional[requests.Response]
+          If the url is None, only print and return None. Otherwise, post
+          message to url and return the response.
+
+        """
+        contents = self._create_body_text(message, extra_text)
+        response = requests.post(self.url, json=contents)
+        return response

--- a/src/aind_codeocean_utils/alert_bot.py
+++ b/src/aind_codeocean_utils/alert_bot.py
@@ -1,12 +1,20 @@
+"""Module with Alert Bot for notifications on MS Teams"""
 import requests
 from typing import Optional
-
 
 
 class AlertBot:
     """Class to handle sending alerts and messages in MS Teams."""
 
     def __init__(self, url: str):
+        """
+        AlertBot constructor
+
+        Parameters
+        ----------
+        url : str
+          The url to send the message to
+        """
         self.url = url
 
     @staticmethod
@@ -29,7 +37,12 @@ class AlertBot:
 
         """
         body: list = [
-            {"type": "TextBlock", "size": "Medium", "weight": "Bolder", "text": message}
+            {
+                "type": "TextBlock",
+                "size": "Medium",
+                "weight": "Bolder",
+                "text": message,
+            }
         ]
         if extra_text is not None:
             body.append({"type": "TextBlock", "text": extra_text})
@@ -42,7 +55,8 @@ class AlertBot:
                         "type": "AdaptiveCard",
                         "body": body,
                         "$schema": (
-                            "http://adaptivecards.io/schemas/adaptive-card.json"
+                            "http://adaptivecards.io/schemas/"
+                            "adaptive-card.json"
                         ),
                         "version": "1.0",
                     },

--- a/src/aind_codeocean_utils/codeocean_job.py
+++ b/src/aind_codeocean_utils/codeocean_job.py
@@ -20,7 +20,6 @@ from aind_data_schema.core.data_description import (
     DataLevel,
     datetime_to_name_string,
 )
-
 from aind_codeocean_utils.models.config import (
     CaptureResultConfig,
     CodeOceanJobConfig,
@@ -499,7 +498,7 @@ class CodeOceanJob:
         # 1. register data assets (optional)
         input_data_assets = None
         if self.job_config.register_config is not None:
-            logger.info("Registering data asset")
+            logger.info(f"Registering data asset {self.job_config.register_config.prefix}")
             register_data_asset_response = (
                 self._register_data_and_update_permissions(
                     self.job_config.register_config

--- a/src/aind_codeocean_utils/codeocean_job.py
+++ b/src/aind_codeocean_utils/codeocean_job.py
@@ -498,7 +498,10 @@ class CodeOceanJob:
         # 1. register data assets (optional)
         input_data_assets = None
         if self.job_config.register_config is not None:
-            logger.info(f"Registering data asset {self.job_config.register_config.prefix}")
+            logger.info(
+                "Registering data asset "
+                f"{self.job_config.register_config.prefix}"
+            )
             register_data_asset_response = (
                 self._register_data_and_update_permissions(
                     self.job_config.register_config

--- a/tests/test_alert_bot.py
+++ b/tests/test_alert_bot.py
@@ -1,0 +1,43 @@
+"""Testing Alerts"""
+import unittest
+from unittest import mock
+from unittest.mock import MagicMock, call
+
+from aind_codeocean_utils.alert_bot import AlertBot
+
+
+class TestAlertBot(unittest.TestCase):
+    """Tests methods in AlertBot class"""
+
+    @mock.patch("requests.post")
+    def test_send_message(self, mocked_post: MagicMock) -> None:
+        """
+        Tests that the message is being sent correctly
+        Parameters
+        ----------
+        mocked_post : MagicMock
+          mock the request.post calls
+        mock_print : MagicMock
+          mock the print calls
+
+        Returns
+        -------
+        None
+
+        """
+        alert_bot = AlertBot("testing_url.com")
+        alert_bot.send_message(message="Test Message")
+        contents0 = alert_bot._create_body_text("Test Message", None)
+        mocked_post.assert_called_once_with("testing_url.com", json=contents0)
+        alert_bot.send_message(message="Another Message", extra_text="With extra text")
+        contents1 = alert_bot._create_body_text("Another Message", "With extra text")
+        mocked_post.assert_has_calls(
+            [
+                call("testing_url.com", json=contents0),
+                call("testing_url.com", json=contents1),
+            ]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_alert_bot.py
+++ b/tests/test_alert_bot.py
@@ -29,8 +29,12 @@ class TestAlertBot(unittest.TestCase):
         alert_bot.send_message(message="Test Message")
         contents0 = alert_bot._create_body_text("Test Message", None)
         mocked_post.assert_called_once_with("testing_url.com", json=contents0)
-        alert_bot.send_message(message="Another Message", extra_text="With extra text")
-        contents1 = alert_bot._create_body_text("Another Message", "With extra text")
+        alert_bot.send_message(
+            message="Another Message", extra_text="With extra text"
+        )
+        contents1 = alert_bot._create_body_text(
+            "Another Message", "With extra text"
+        )
         mocked_post.assert_has_calls(
             [
                 call("testing_url.com", json=contents0),

--- a/tests/test_codeocean_job.py
+++ b/tests/test_codeocean_job.py
@@ -15,7 +15,6 @@ from aind_codeocean_api.models.data_assets_requests import (
 )
 
 from aind_codeocean_utils.codeocean_job import CodeOceanJob
-from aind_codeocean_utils.alert_bot import AlertBot
 from aind_codeocean_utils.models.config import (
     CaptureResultConfig,
     CodeOceanJobConfig,

--- a/tests/test_codeocean_job.py
+++ b/tests/test_codeocean_job.py
@@ -15,6 +15,7 @@ from aind_codeocean_api.models.data_assets_requests import (
 )
 
 from aind_codeocean_utils.codeocean_job import CodeOceanJob
+from aind_codeocean_utils.alert_bot import AlertBot
 from aind_codeocean_utils.models.config import (
     CaptureResultConfig,
     CodeOceanJobConfig,


### PR DESCRIPTION
Fixes #16 

Ported `AlertBot` from [`aind-trigger-codeocean`](https://github.com/AllenNeuralDynamics/aind-trigger-codeocean/blob/main/code/aind_trigger_codeocean/pipelines.py#L31)

@jtyoung84 I just made one change: the `url` is required and the `send_message` only posts requests. I think that the printing behavior was only for testing.