### PR TITLE
feat: updates tests and docs

### DIFF
--- a/src/aind_codeocean_utils/alert_bot.py
+++ b/src/aind_codeocean_utils/alert_bot.py
@@ -1,6 +1,7 @@
 """Module with Alert Bot for notifications on MS Teams"""
-import requests
 from typing import Optional
+
+import requests
 
 
 class AlertBot:

--- a/src/aind_codeocean_utils/api_handler.py
+++ b/src/aind_codeocean_utils/api_handler.py
@@ -1,37 +1,37 @@
 """Module of classes to handle interfacing with the Code Ocean index."""
 
 import logging
-from typing import Dict, Iterator, List, Optional
 from datetime import datetime
-import boto3
-import botocore
+from typing import Dict, Iterator, List, Optional
 
 from aind_codeocean_api.codeocean import CodeOceanClient
+from botocore.client import BaseClient
 
 
 class APIHandler:
     """Class to handle common tasks modifying the Code Ocean index."""
 
-    def __init__(self, co_client: CodeOceanClient, dryrun: bool = False):
+    def __init__(
+        self,
+        co_client: CodeOceanClient,
+        s3: Optional[BaseClient] = None,
+        dryrun: bool = False,
+    ):
         """
         Class constructor
         Parameters
         ----------
         co_client : CodeOceanClient
+        s3 : Optional[BaseClient]
+          For operations that require communicating with AWS S3, a user will
+          need to create a boto.client('s3') object. Default is None.
         dryrun : bool
           Perform a dryrun of the operations without actually making any
-          changes to the index.
+          changes to the index. Default is False.
         """
         self.co_client = co_client
+        self.s3 = s3
         self.dryrun = dryrun
-        self._s3 = None
-
-    @property
-    def s3(self):
-        """Return a boto3 s3 client."""
-        if self._s3 is None:
-            self._s3 = boto3.client("s3")
-        return self._s3
 
     def update_tags(
         self,
@@ -106,8 +106,23 @@ class APIHandler:
                 )
                 logging.info(response.json())
 
-    def find_archived_data_assets_to_delete(self, keep_after: datetime):
-        """find archived data assets that are safe to delete"""
+    def find_archived_data_assets_to_delete(
+        self, keep_after: datetime
+    ) -> List[dict]:
+        """
+        Find archived data assets which were last used before the keep_after
+        datetime.
+        Parameters
+        ----------
+        keep_after : datetime
+          Archived data assets have a last_used field
+
+        Returns
+        -------
+        List[dict]
+          A list of data assets objects
+
+        """
 
         assets = self.co_client.search_all_data_assets(archived=True).json()[
             "results"
@@ -157,8 +172,16 @@ class APIHandler:
 
         return assets_to_delete
 
-    def find_external_data_assets(self):
-        """find all external data assets"""
+    def find_external_data_assets(self) -> Iterator[dict]:
+        """
+        Find external data assets by checking if the data asset responses
+        from CodeOcean have a source bucket and are of type 'dataset'.
+        Returns
+        -------
+        Iterator[dict]
+          An iterator of data assets objects
+
+        """
 
         response = self.co_client.search_all_data_assets(type="dataset")
         assets = response.json()["results"]
@@ -168,22 +191,49 @@ class APIHandler:
             if bucket:
                 yield asset
 
-    def find_nonexistent_external_data_assets(self):
-        """find external data assets that do not exist"""
+    def find_nonexistent_external_data_assets(self) -> Iterator[dict]:
+        """
+        Find external data assets that do not exist in S3. Makes a call
+        to CodeOcean and returns an iterator over external data assets.
+        Steps through each external data asset and queries for the existence
+        in S3. If it exists or an error occurs while querying S3, then the
+        data asset will not be added to the return response.
+        Returns
+        -------
+        Iterator[dict]
+           An iterator of data asset objects.
+
+        """
 
         for asset in self.find_external_data_assets():
             sb = asset["sourceBucket"]
 
             try:
-                exists = self.bucket_prefix_exists(sb["bucket"], sb["prefix"])
-                logging.info(f"{sb['bucket']} {sb['prefix']} exists? {exists}")
+                exists = self._bucket_prefix_exists(sb["bucket"], sb["prefix"])
+                logging.debug(
+                    f"{sb['bucket']} {sb['prefix']} exists? {exists}"
+                )
                 if not exists:
                     yield asset
-            except botocore.exceptions.ClientError as e:
-                logging.warning(e)
+            except Exception as e:
+                logging.error(e)
 
-    def bucket_prefix_exists(self, bucket: str, prefix: str) -> bool:
-        """Check if prefix exists. Prefix could be empty."""
+    def _bucket_prefix_exists(self, bucket: str, prefix: str) -> bool:
+        """
+        Check if bucket/prefix exists in S3. Prefix could be empty string.
+        Parameters
+        ----------
+        bucket : str
+          S3 bucket
+        prefix : str
+          S3 object prefix
+
+        Returns
+        -------
+        bool
+          True if bucket and prefix exists in S3. False otherwise.
+
+        """
 
         prefix = prefix.rstrip("/")
         resp = self.s3.list_objects(

--- a/src/aind_codeocean_utils/codeocean_job.py
+++ b/src/aind_codeocean_utils/codeocean_job.py
@@ -21,6 +21,7 @@ from aind_data_schema.core.data_description import (
     DataLevel,
     datetime_to_name_string,
 )
+
 from aind_codeocean_utils.models.config import (
     CaptureResultConfig,
     CodeOceanJobConfig,


### PR DESCRIPTION
- Moves s3 constructor to outside APIHandler. There was some  inconsistent behavior in some of my tests. We can assume that the user creates and closes it on their own.
- Updates doc strings
- There are other types of exceptions that occurred when using the boto client other than the ClientError. I generalized the exception to just Exception.
- Added return type hints
- Updated a few unit tests to use the unittest assert methods and added some checks on the mock log messages.